### PR TITLE
Add label_margin attribute to edges, and default_edge_label_margin to the diagram

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 2.0.1 (unreleased)
 ------------------
+* Add "edge_label_margin" attribute to edges
 * Fix a bug
 
   - Separator does not support both default_fontsize and default_textcolor

--- a/src/seqdiag/elements.py
+++ b/src/seqdiag/elements.py
@@ -83,6 +83,7 @@ class EdgeSeparator(blockdiag.elements.Base):
 
 class DiagramEdge(blockdiag.elements.DiagramEdge):
     notecolor = (255, 182, 193)  # LightPink
+    label_margin = 2
 
     # name -> (dir, style, asynchronous)
     ARROW_DEF = {
@@ -104,11 +105,16 @@ class DiagramEdge(blockdiag.elements.DiagramEdge):
     def clear(cls):
         super(DiagramEdge, cls).clear()
         cls.notecolor = (255, 182, 193)
+        cls.label_margin = 2
 
     @classmethod
     def set_default_note_color(cls, color):
         color = images.color_to_rgb(color)
         cls.notecolor = color
+
+    @classmethod
+    def set_default_label_margin(cls, margin):
+        cls.label_margin = int(margin)
 
     def __init__(self, node1, node2):
         super(DiagramEdge, self).__init__(node1, node2)
@@ -190,6 +196,9 @@ class DiagramEdge(blockdiag.elements.DiagramEdge):
 
             if self.node1 == self.node2 and self.dir in ('forward', 'back'):
                 self.activate = False
+
+    def set_label_margin(self, margin):
+        self.label_margin = int(margin)
 
     def to_desctable(self):
         params = (self.dir, self.style, self.asynchronous)
@@ -286,6 +295,9 @@ class Diagram(blockdiag.elements.Diagram):
     def set_default_note_color(self, color):
         color = images.color_to_rgb(color)
         self._DiagramEdge.set_default_note_color(color)
+
+    def set_default_edge_label_margin(self, margin):
+        self._DiagramEdge.set_default_label_margin(margin)
 
     def set_default_fontfamily(self, fontfamily):
         super(Diagram, self).set_default_fontfamily(fontfamily)

--- a/src/seqdiag/metrics.py
+++ b/src/seqdiag/metrics.py
@@ -194,6 +194,7 @@ class DiagramMetrics(blockdiag.metrics.DiagramMetrics):
             else:
                 width = (self.cell(edge.right_node).center.x -
                          self.cell(edge.left_node).center.x -
+                         edge.label_margin * 2 -
                          self.cellsize * 4)  # 4: width of activity and padding
             width, height = self.textsize(edge.label, width=width,
                                           font=self.font_for(edge))
@@ -402,15 +403,19 @@ class EdgeMetrics(object):
 
         if self.edge.direction == 'self':
             x = m.node(self.edge.node1).bottom.x + \
-                self.activity_line_width(self.edge.node1)
+                self.activity_line_width(self.edge.node1) + \
+                self.edge.label_margin * 2
         elif self.edge.direction == 'right':
             x = m.node(self.edge.left_node).bottom.x + \
                 self.activity_line_width(self.edge.left_node) + \
+                self.edge.label_margin * 2 + \
                 self.metrics.cellsize // 2
         else:  # left
-            x = m.node(self.edge.right_node).bottom.x - self.edge.textwidth
+            x = m.node(self.edge.right_node).bottom.x - \
+                self.edge.textwidth - \
+                self.edge.label_margin * 2
 
-        y1 = self.baseheight - self.edge.textheight
+        y1 = self.baseheight - self.edge.textheight - self.edge.label_margin
         return Box(x, y1, x + self.edge.textwidth, y1 + self.edge.textheight)
 
     def activity_line_width(self, node):


### PR DESCRIPTION
Make the position of the label of the edge adjustable via `label_margin` attribute and `default_edge_label_margin` attribute.

before:
```
{ A -> B [label = blah]; B -> A [label = blah] }
```
![out1](https://user-images.githubusercontent.com/748828/122680625-19033780-d22b-11eb-8464-81343d3fe0a8.png)


after:
```
{
  A -> B [label = blah];
  A -> B [label = margin4, label_margin = 4, noactivate];
  B -> A [label = blah];
  B -> A [label = margin4, label_margin = 4, noactivate];
}
```
![out2](https://user-images.githubusercontent.com/748828/122680628-1b659180-d22b-11eb-83d7-3ca82b3bf8ec.png)
