### PR TITLE
allow href for line separator

### DIFF
--- a/src/seqdiag/builder.py
+++ b/src/seqdiag/builder.py
@@ -157,7 +157,7 @@ class DiagramTreeBuilder(object):
                     group.set_attribute(stmt)
 
             elif isinstance(stmt, parser.Separator):
-                sep = EdgeSeparator(stmt.type, unquote(stmt.value))
+                sep = EdgeSeparator(stmt.type, unquote(stmt.value), stmt.href)
                 sep.group = group
                 self.diagram.separators.append(sep)
                 group.edges.append(sep)

--- a/src/seqdiag/drawer.py
+++ b/src/seqdiag/drawer.py
@@ -152,17 +152,22 @@ class DiagramDraw(blockdiag.drawer.DiagramDraw):
                                  fill=edge.color, halign=halign)
 
     def separator(self, sep):
+        if sep.href and self.format == 'SVG':
+            drawer = self.drawer.anchor(sep.href)
+        else:
+            drawer = self.drawer
+
         m = self.metrics.separator(sep)
         for line in m.lines:
-            self.drawer.line(line, fill=self.fill, style=sep.style)
+            drawer.line(line, fill=self.fill, style=sep.style)
 
         if sep.type == 'delay':
-            self.drawer.rectangle(m.labelbox, fill='white', outline='white')
+            drawer.rectangle(m.labelbox, fill='white', outline='white')
         elif sep.type == 'divider':
-            self.drawer.rectangle(m.labelbox, fill=sep.color,
+            drawer.rectangle(m.labelbox, fill=sep.color,
                                   outline=sep.linecolor)
 
-        self.drawer.textarea(m.labelbox, sep.label,
+        drawer.textarea(m.labelbox, sep.label,
                              self.metrics.font_for(sep), fill=sep.textcolor)
 
     def altblock(self, block):

--- a/src/seqdiag/elements.py
+++ b/src/seqdiag/elements.py
@@ -67,9 +67,10 @@ class EdgeSeparator(blockdiag.elements.Base):
         cls.basecolor = (208, 208, 208)
         cls.linecolor = (0, 0, 0)
 
-    def __init__(self, _type, label):
+    def __init__(self, _type, label, href):
         super(EdgeSeparator, self).__init__()
         self.label = label
+        self.href = href
         self.group = None
         self.style = None
         self.color = self.basecolor


### PR DESCRIPTION
 I would like to allow href in the separator line. This PR works for this syntax:

```
 === Separator line === https://example.com
```
Maybe the syntax should be different, for example this:

```
 === Separator line === [href="https://example.com"]
```

Another problem is that I didn't understand how to properly use the separator regex in the pattern. Suggestions welcome!
